### PR TITLE
feat: add from_features constructor for pre-loaded features

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::error;
 
+use crate::dto::GrowthBookResponse;
 use crate::env::Environment;
 use crate::error::GrowthbookError;
 use crate::gateway::GrowthbookGateway;
@@ -90,6 +91,15 @@ impl GrowthBookClient {
         });
 
         Ok(GrowthBookClient { gb: growthbook_writable })
+    }
+
+    pub fn from_features(response: GrowthBookResponse) -> Self {
+        GrowthBookClient {
+            gb: Arc::new(RwLock::new(GrowthBook {
+                forced_variations: response.forced_variations,
+                features: response.features,
+            })),
+        }
     }
 
     fn read_gb(&self) -> GrowthBook {

--- a/tests/from_features.rs
+++ b/tests/from_features.rs
@@ -1,0 +1,30 @@
+#[cfg(test)]
+mod test {
+    use growthbook_rust_sdk::client::{GrowthBookClient, GrowthBookClientTrait};
+    use growthbook_rust_sdk::dto::GrowthBookResponse;
+    use rstest::rstest;
+    use serde_json::json;
+
+    #[rstest]
+    #[tokio::test]
+    async fn should_create_client_from_features() -> Result<(), Box<dyn std::error::Error>> {
+        let response: GrowthBookResponse = serde_json::from_value(json!({
+            "features": {
+                "simple-flag": {
+                    "defaultValue": true
+                },
+                "disabled-flag": {
+                    "defaultValue": false
+                }
+            }
+        }))?;
+
+        let client = GrowthBookClient::from_features(response);
+
+        assert!(client.is_on("simple-flag", None));
+        assert!(!client.is_on("disabled-flag", None));
+        assert!(!client.is_on("non-existent", None));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Objective
Add parity with the Python SDK by allowing client creation from pre-fetched features.
https://github.com/growthbook/growthbook-python/blob/main/growthbook/growthbook.py#L673

## Proposed changes
<!-- Tell us what your proposal is. Here, you can add evidence like screenshots or code snippets. -->
Add a `from_features` constructor to `GrowthBookClient` that accepts a `GrowthBookResponse`, matching the Python SDK's ability to initialize with `features={}`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `GrowthBookClient::from_features` to initialize the client from a `GrowthBookResponse`, plus a test validating feature evaluation.
> 
> - **Client**
>   - Add `GrowthBookClient::from_features(response: GrowthBookResponse)` to initialize internal `GrowthBook` with pre-fetched `features` and `forced_variations`.
> - **Tests**
>   - Add `tests/from_features.rs` verifying feature toggles using the new constructor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69d418d423d23d261bf65016e692c1cf70037e3e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->